### PR TITLE
Fix heading in treasury standard doc

### DIFF
--- a/bitcoin_treasury_standard_canada.md
+++ b/bitcoin_treasury_standard_canada.md
@@ -1,6 +1,6 @@
 # Bitcoin Treasury Standard Canada
 
-## Canurta Helping Consult Canadian Companies on Bitcoin Treasury Standards
+## How Canurta Helps Canadian Companies Implement Bitcoin Treasury Standards
 
 ## Welcome Message
 


### PR DESCRIPTION
## Summary
- fix grammar in the Bitcoin Treasury Standard document heading

## Testing
- `git status --short`